### PR TITLE
Feature/dockerizing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
-language: python
-python:
-  - "3.4"
-before_install:
-  - export PYTHONPATH=$PYTHONPATH:$(pwd)
+sudo: required
+
+language: generic
+
+services:
+  - docker
+
+install:
+  - docker build --tag=hondash .
+
 script:
-  - make test
-after_success:
-  - codecov
+  - docker run hondash
+    /bin/sh -c '. venv/bin/activate && make test'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Docker image for installing dependencies on Linux and running tests.
+# Build with:
+# docker build --tag=hondash .
+# Run with:
+# docker run hondash /bin/sh -c '. venv/bin/activate && make test'
+# Or for interactive shell:
+# docker run -it --rm hondash
+# TODO:
+#	- delete archives to keep small the container small
+#	- setup caching (for apt, and pip)
+FROM ubuntu:18.04
+
+# configure locale
+RUN apt update -qq > /dev/null && apt install --yes --no-install-recommends \
+    locales && \
+    locale-gen en_US.UTF-8
+ENV LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8"
+
+# install system dependencies
+RUN apt update -qq > /dev/null && apt install --yes --no-install-recommends \
+	python3 python3-dev virtualenv make lsb-release pkg-config git build-essential \
+    libssl-dev tox
+
+WORKDIR /app
+COPY . /app
+RUN make virtualenv

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ clean:
 	@rm -rf venv
 
 virtualenv: clean
-	virtualenv -p python3.4 venv
+	virtualenv -p python3 venv
 	. venv/bin/activate; pip install -r requirements.txt
 
 run:

--- a/README.md
+++ b/README.md
@@ -63,5 +63,5 @@ In detail the board offers:
 
 Once you are inside the HonDash project folder run this:
 ```sh
-export PYTHONPATH='.'
+export PYTHONPATH='src'
 ```

--- a/src/backend/backend.py
+++ b/src/backend/backend.py
@@ -1,12 +1,12 @@
 from time import sleep
 from autobahn_sync import publish, run
 
-from src.devices.kpro import Kpro
-from src.devices.time import Time
-from src.devices.odometer import Odometer
-from src.devices.digital_input import DigitalInput
-from src.devices.analog_inputs import AnalogInputs
-from src.devices.formula import Formula
+from devices.kpro import Kpro
+from devices.time import Time
+from devices.odometer import Odometer
+from devices.digital_input import DigitalInput
+from devices.analog_inputs import AnalogInputs
+from devices.formula import Formula
 
 run()
 

--- a/src/bench/analog_inputs.py
+++ b/src/bench/analog_inputs.py
@@ -1,4 +1,4 @@
-from src.devices.mcp3208 import Mcp3208
+from devices.mcp3208 import Mcp3208
 
 an = Mcp3208()
 

--- a/src/bench/digital_inputs.py
+++ b/src/bench/digital_inputs.py
@@ -1,4 +1,4 @@
-from src.devices.digital_input import DigitalInput
+from devices.digital_input import DigitalInput
 
 di = DigitalInput(22)
 

--- a/src/bench/dummy_backend.py
+++ b/src/bench/dummy_backend.py
@@ -1,8 +1,8 @@
 import random
 from time import sleep
 from autobahn_sync import publish, call, register, subscribe, run
-from src.devices.time import Time
-from src.devices.odometer import Odometer
+from devices.time import Time
+from devices.odometer import Odometer
 
 run()
 

--- a/src/bench/kpro.py
+++ b/src/bench/kpro.py
@@ -1,6 +1,6 @@
 #sudo python bench/test.py
 from __future__ import print_function
-from src.devices.kpro import Kpro
+from devices.kpro import Kpro
 from reprint import output
 
 

--- a/src/tests/devices/test_formula.py
+++ b/src/tests/devices/test_formula.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from src.devices.formula import Formula
+from devices.formula import Formula
 
 
 class TestFormula(TestCase):

--- a/src/tests/devices/test_kpro.py
+++ b/src/tests/devices/test_kpro.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from devices.kpro import Kpro
 
@@ -6,7 +6,11 @@ from devices.kpro import Kpro
 class TestKpro(TestCase):
 
     def setUp(self):
-        self.kpro = Kpro()
+        # we are not unit testing USB features and find() may raise a
+        # `usb.core.NoBackendError` e.g. on Docker
+        with mock.patch('usb.core.find') as m_find:
+            m_find.return_value = None
+            self.kpro = Kpro()
         self.kpro.data0 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         self.kpro.data1 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/src/tests/devices/test_time.py
+++ b/src/tests/devices/test_time.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from src.devices.time import Time
+from devices.time import Time
 
 
 class TestTime(TestCase):


### PR DESCRIPTION
Now running test from Docker, tests are green in Travis, see more details below.

1) Run Travis tests from Docker
Gives more control over the testing environment.
Currently build in latest Ubuntu LTS (18.04).
However I dropped codecov from now and we'll hook it back later.

2) Mock usb.core.find()
`usb.core.find()` would raise a `usb.core.NoBackendError` if no
backend are available, e.g. on default Docker configuration.
We're not unit testing USB feature anyway.

3) Fixes import removing the leading "src" (https://github.com/pablobuenaposada/HonDash/pull/5)