### PR TITLE
Fixes coverage tests and introduce coveralls.io service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 venv/
-.git/
 **/.pytest_cache/
 *.pyc
 **/__pycache__

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PIP=$(VIRTUAL_ENV)/bin/pip
 PYTEST=$(VIRTUAL_ENV)/bin/pytest
 ISORT=$(VIRTUAL_ENV)/bin/isort
 FLAKE8=$(VIRTUAL_ENV)/bin/flake8
+COVERALLS=$(VIRTUAL_ENV)/bin/coveralls
 CROSSBAR=$(VIRTUAL_ENV)/bin/crossbar
 PYTHON_VERSION=3
 PYTHON_WITH_VERSION=python$(PYTHON_VERSION)
@@ -54,7 +55,8 @@ dummy:
 	open -a "Google Chrome" src/frontend/index.html
 
 test: lint
-	PYTHONPATH=src $(PYTEST) src/tests --cov=./
+	PYTHONPATH=src $(PYTEST) --cov src/ src/tests
+	@if [ -n "$$CI" ] && [ -f $(COVERALLS) ]; then $(COVERALLS); fi \
 
 lint/isort-fix: virtualenv
 	$(ISORT) -rc src
@@ -71,7 +73,7 @@ docker/build:
 	docker build --tag=hondash .
 
 docker/run/test:
-	docker run hondash /bin/sh -c 'make test'
+	docker run --env-file docker.env hondash /bin/sh -c 'make test'
 
 docker/run/shell:
 	docker run -it --rm hondash

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![alt tag](https://raw.github.com/pablobuenaposada/HonDash/master/docs/logo/hondash.png)
 
 [![Build Status](https://secure.travis-ci.org/pablobuenaposada/HonDash.png?branch=master)](http://travis-ci.org/pablobuenaposada/HonDash)
-[![alt tag](https://codecov.io/gh/pablobuenaposada/hondash/branch/master/graph/badge.svg)](https://codecov.io/gh/pablobuenaposada/hondash/)
+[![Coverage Status](https://coveralls.io/repos/github/pablobuenaposada/HonDash/badge.svg?branch=master)](https://coveralls.io/github/pablobuenaposada/HonDash?branch=master)
 
 Start from checking [hondash.com](https://hondash.com)!
 

--- a/docker.env
+++ b/docker.env
@@ -1,0 +1,7 @@
+# used by coveralls.io, refs:
+# https://coveralls-python.readthedocs.io/en/latest/usage/tox.html#travisci
+CI
+TRAVIS
+TRAVIS_BRANCH
+TRAVIS_JOB_ID
+TRAVIS_PULL_REQUEST

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+coveralls
 pytest==4.3.0
 pyusb==1.0.2
 numpy==1.14.2
@@ -5,7 +6,6 @@ pytemperature==1.0
 reprint==0.5.1
 crossbar==19.6.1
 autobahn_sync==0.3.2
-codecov
 pytest-cov
 isort
 flake8


### PR DESCRIPTION
- uses `docker.env` to pass env variables used by the service
- uses the `.git/` directory for coveralls.io stats

Result of this PR on my fork for Travis and Coveralls.io:

- https://travis-ci.org/AndreMiras/HonDash/builds/591503079
- https://coveralls.io/jobs/53838403