### PR TITLE
Configurable `devices.setup_file` `file_name` path

### DIFF
--- a/src/devices/setup_file.py
+++ b/src/devices/setup_file.py
@@ -7,8 +7,9 @@ OS_CONFIG_FILE = '/boot/config.txt'
 
 
 class SetupFile:
-    def __init__(self):
-        with open(FILE_NAME) as file:
+    def __init__(self, file_name=FILE_NAME):
+        self.file_name = file_name
+        with open(self.file_name) as file:
             self.json = json.load(file)
 
     def get_value(self, key):
@@ -30,15 +31,15 @@ class SetupFile:
         return getattr(Formula, formula)
 
     def load_setup(self):
-        with open(FILE_NAME) as file:
+        with open(self.file_name) as file:
             self.json = json.load(file)
         return self.json
 
     def save_setup(self, setup):
         self.json.update(setup)
-        with open(FILE_NAME, 'w') as file:
+        with open(self.file_name, 'w') as file:
             json.dump(self.json, file, indent=2, sort_keys=True)
-        self.__init__()
+        self.__init__(self.file_name)
 
     @staticmethod
     def rotate_screen(enable):

--- a/src/tests/backend/test_setup_file.py
+++ b/src/tests/backend/test_setup_file.py
@@ -1,3 +1,5 @@
+import os
+from shutil import copyfile
 from tempfile import NamedTemporaryFile
 
 from devices import setup_file
@@ -8,7 +10,12 @@ class TestSetupFile:
     def setup_method(self):
         # note that the json file loaded in this test is the one used also as example
         # located in the root folder of this project
-        self.setup = setup_file.SetupFile()
+        self.file_name = NamedTemporaryFile().name
+        copyfile(setup_file.FILE_NAME, self.file_name)
+        self.setup = setup_file.SetupFile(self.file_name)
+
+    def teardown_method(self):
+        os.remove(self.file_name)
 
     def test_get_value(self):
         """


### PR DESCRIPTION
Makes it possible to use temporary files on tests. Running tests twice
is now passing. Test command used was:
```sh
PYTHONPATH=src venv/bin/pytest \
src/tests/backend/test_setup_file.py::TestSetupFile::test_update_key
```
closes #59