### PR TITLE
Adds image creation instructions :cd:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ venv/
 .pytest_cache/
 .coverage
 src/setup/lib/node_modules/
+pishrink.sh
+*.img

--- a/Makefile
+++ b/Makefile
@@ -89,3 +89,11 @@ docker/run/shell:
 
 docker/run/lint:
 	docker run $(DOCKER_IMAGE) /bin/sh -c 'make lint'
+
+sd-image/create:
+	sudo dd bs=1024 if=$(path) of=full_size_image.img
+
+sd-image/shrink:
+	wget -c https://raw.githubusercontent.com/Drewsif/PiShrink/master/pishrink.sh
+	chmod +x pishrink.sh
+	sudo ./pishrink.sh full_size_image.img shrinked_image.img

--- a/src/README.md
+++ b/src/README.md
@@ -117,3 +117,19 @@ sudo rm /etc/xdg/lxsession/LXDE-pi/sshpwd.sh
 ### Boot faster
 rcconf
 disable bluethoot, alsa...
+
+### Create SD card image file
+Check your sd card path with:
+```sh
+diskutil list
+```
+
+use the provided make command to build a full sd card image:
+```sh
+make sd-image/create path=/dev/rdisk6
+```
+
+shrink it:
+```sh
+make sd-image/shrink
+```


### PR DESCRIPTION
Basically adds some makefile commands to create the sd card image and shrink it using https://github.com/Drewsif/PiShrink tool that resizes it to a smaller image and also handles the expansion of the full volume in the first boot up.
Closes #67 and #91