### PR TITLE
remove neutral gear

### DIFF
--- a/src/backend/devices/kpro/kpro.py
+++ b/src/backend/devices/kpro/kpro.py
@@ -295,10 +295,7 @@ class Kpro:
             constants.KPRO23_ID: constants.KPRO23_GEAR,
             constants.KPRO4_ID: constants.KPRO4_GEAR,
         }
-        gear = self.get_value_from_kpro(indexes, self.data0)
-        if gear == 0:
-            return "N"
-        return gear
+        return self.get_value_from_kpro(indexes, self.data0)
 
     @property
     def eps(self):

--- a/src/tests/backend/devices/kpro/test_kpro.py
+++ b/src/tests/backend/devices/kpro/test_kpro.py
@@ -372,9 +372,7 @@ class TestKpro:
     @pytest.mark.parametrize(
         "version, index, value, result",
         (
-            (constants.KPRO23_ID, constants.KPRO23_GEAR, 0, "N"),
             (constants.KPRO23_ID, constants.KPRO23_GEAR, 1, 1),
-            (constants.KPRO4_ID, constants.KPRO4_GEAR, 0, "N"),
             (constants.KPRO4_ID, constants.KPRO4_GEAR, 1, 1),
         ),
     )

--- a/src/tests/backend/test_main.py
+++ b/src/tests/backend/test_main.py
@@ -66,7 +66,7 @@ class TestMain:
     def test_update(self):
         expected_data = {
             "bat": 0.0,
-            "gear": "N",
+            "gear": 0,
             "iat": 0,
             "tps": 0,
             "ect": 0,


### PR DESCRIPTION
neutral gear was not real, so kill it and whatever kpro returns is what is gonna be displayed