### PR TITLE
:memo: Build badge to link to Build workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![alt tag](https://raw.github.com/pablobuenaposada/HonDash/master/docs/logo/hondash.png)
 
-![Build Status](https://github.com/pablobuenaposada/HonDash/workflows/Build/badge.svg)
+[![Build](https://github.com/pablobuenaposada/HonDash/workflows/Build/badge.svg)](https://github.com/pablobuenaposada/HonDash/actions?query=workflow%3ABuild)
 [![Coverage Status](https://coveralls.io/repos/github/pablobuenaposada/HonDash/badge.svg?branch=master)](https://coveralls.io/github/pablobuenaposada/HonDash?branch=master)
 
 Start from checking [hondash.com](https://hondash.com)!


### PR DESCRIPTION
Currently clicking the build badge links to the image which is not so
useful. This fix links it to the workflow.
I'm not sure why the official GitHub documentation doesn't have this
right.