### PR TITLE
fix chromium update pop-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ run_rpi:
 	cp -n default_setup.json setup.json
 	sudo PYTHONPATH=src $(PYTHON) src/backend/main.py &
 	sleep 5
-	chromium-browser --kiosk --incognito src/frontend/index.html &
+	chromium-browser --kiosk --check-for-update-interval=604800 --incognito src/frontend/index.html &
 
 dummy:
 	cp -n default_setup.json setup.json || true


### PR DESCRIPTION
Seems raspbian chromium is for now not gonna get rid of the update pop-up,
so for now the extending the check for update process would do the job.
Reference: https://www.raspberrypi.org/forums/viewtopic.php?f=63&t=264399