### PR TITLE
Bug fix for no ecu connected

### DIFF
--- a/src/tests/backend/devices/test_ecu.py
+++ b/src/tests/backend/devices/test_ecu.py
@@ -17,22 +17,22 @@ class TestEcu:
             (
                 kpro_constants.KPRO23_ID_VENDOR,
                 kpro_constants.KPRO23_ID_PRODUCT,
-                (Kpro, type(None)),
+                Kpro,
             ),
             (
                 kpro_constants.KPRO4_ID_VENDOR,
                 kpro_constants.KPRO4_ID_PRODUCT,
-                (Kpro, type(None)),
+                Kpro,
             ),
             (
                 s300_constants.S3003_ID_VENDOR,
                 s300_constants.S3003_ID_PRODUCT,
-                (Kpro, S300),
+                S300,
             ),
             (
                 None,
                 None,
-                (Kpro, S300),
+                type(None),
             ),
         ),
     )
@@ -49,8 +49,7 @@ class TestEcu:
             m_find.side_effect = found_device
             ecu = Ecu()
 
-        assert isinstance(ecu.kpro, result[0])
-        assert isinstance(ecu.s300, result[1])
+        assert isinstance(ecu.ecu, result)
 
     @pytest.mark.parametrize(
         "vendor_id, product_id, value, result",


### PR DESCRIPTION
When the ecu was not connected the websocket was brain farting, seems that we are creating kpro and s300 instances
too fast trying to reconnect and for some reason the websocket was not really working or not sending anything to the frontend.
Commit edaca902623b5dc75bb49fe137cc42a73ec992e1 was supposed to be version 3.0.0 but this new one would overwrite it since
the other was has the bug and I don´t really want to make a new release.